### PR TITLE
Remove moment dependency to reduce bundle sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,14 +51,13 @@
   },
   "dependencies": {
     "astronomia": "^1.3.5",
-    "caldate": "^1.0.0",
     "date-chinese": "^1.0.2",
     "date-easter": "^0.2.2",
+    "date-fns": "^1.29.0",
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.0",
     "lodash.omit": "^4.5.0",
-    "lodash.set": "^4.3.2",
-    "moment-timezone": "^0.5.13"
+    "lodash.set": "^4.3.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/CalEvent.js
+++ b/src/CalEvent.js
@@ -1,25 +1,37 @@
 'use strict'
 
-const {isDate} = require('./internal/utils')
-const CalDate = require('caldate')
+const {isDate, toTimezone} = require('./internal/utils')
+const addDays = require('date-fns/add_days')
+const startOfDay = require('date-fns/start_of_day')
+const isSameDay = require('date-fns/is_same_day')
+const format = require('date-fns/format')
+const addHours = require('date-fns/add_hours')
+const compareAsc = require('date-fns/compare_asc')
+const setYear = require('date-fns/set_year')
 
 class CalEvent {
   constructor (opts) {
     opts = opts || {}
     this.substitute = opts.substitute
     this.opts = opts
-    this.offset = opts.offset
+    this.offset = opts.offset || 0
     this.dates = []
     if (isDate(opts)) {
-      this.opts = new CalDate(opts)
+      this.opts = new Date(opts)
     }
   }
 
   inYear (year) {
-    const d = (new CalDate(this.opts)).setOffset(this.offset)
-    if (!(d.year && d.year !== year)) {
-      d.year = year
-      this.dates.push(d)
+    let d
+    if (this.opts instanceof Date) {
+      d = toTimezone(this.opts)
+    } else {
+      d = new Date(this.opts.year || year, this.opts.month - 1, this.opts.day)
+    }
+
+    if (!(d.getFullYear() && d.getFullYear() !== year)) {
+      d = setYear(d, year)
+      this.dates.push(addDays(d, this.offset))
     }
     return this
   }
@@ -32,7 +44,7 @@ class CalEvent {
     let res = false
     for (const thisDate of this.dates) {
       for (const date of calEvent.dates) {
-        res |= thisDate.isEqualDate(date)
+        res |= isSameDay(thisDate, date)
       }
     }
     return !!res
@@ -46,20 +58,22 @@ class CalEvent {
   filter (year, active) {
     function isActive (date) {
       if (!active) {
-        if (date.year === year) {
+        if (date.getFullYear() === year) {
           return true
         } else {
           return false
         }
       }
-      const _date = date.toDate()
+
       for (let a of active) {
         const {from, to} = a
+        const fromBeforeOrEqualToDate = (compareAsc(from, date) !== 1)
+        const toAfterDate = (compareAsc(to, date) === 1)
         if (
-          date.year === year &&
-          ((from && to && from <= _date && to > _date) ||
-          (from && !to && from <= _date) ||
-          (!from && to && to > _date))
+          date.getFullYear() === year &&
+          ((from && to && fromBeforeOrEqualToDate && toAfterDate) ||
+          (from && !to && fromBeforeOrEqualToDate) ||
+          (!from && to && toAfterDate))
         ) {
           return true
         }
@@ -83,10 +97,17 @@ class CalEvent {
 
   get (timezone) {
     const arr = this.dates.map((date) => {
+      let endDate
+      if (date.duration) {
+        endDate = addHours(date, date.duration)
+      } else {
+        endDate = startOfDay(addDays(date, 1))
+      }
+
       const o = {
-        date: date.toString(),
-        start: date.toTimezone(timezone),
-        end: date.toEndDate().toTimezone(timezone)
+        date: format(date, 'YYYY-MM-DD HH:mm:ss'),
+        start: toTimezone(date, timezone),
+        end: toTimezone(endDate, timezone)
       }
       this._addSubstitute(date, o)
       return o

--- a/src/CalEvent.js
+++ b/src/CalEvent.js
@@ -2,12 +2,12 @@
 
 const {isDate, toTimezone} = require('./internal/utils')
 const addDays = require('date-fns/add_days')
-const startOfDay = require('date-fns/start_of_day')
-const isSameDay = require('date-fns/is_same_day')
-const format = require('date-fns/format')
 const addHours = require('date-fns/add_hours')
 const compareAsc = require('date-fns/compare_asc')
+const format = require('date-fns/format')
+const isSameDay = require('date-fns/is_same_day')
 const setYear = require('date-fns/set_year')
+const startOfDay = require('date-fns/start_of_day')
 
 class CalEvent {
   constructor (opts) {

--- a/src/CalEventMap.js
+++ b/src/CalEventMap.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const CalEvent = require('./CalEvent')
-const CalDate = require('caldate')
+const addDays = require('date-fns/add_days')
 
 /**
  * Mapper class for mapped calenders like hijri and hebrew
@@ -29,13 +29,12 @@ class CalEventMap extends CalEvent {
             break
           }
         }
-        const d = (new CalDate({
-          year: y,
-          month: firstDays[i] + 1,
-          day: firstDays[i + 1]
-        })).setOffset(this.opts.day - 1)
+        const d = addDays(
+          new Date(y, firstDays[i], (firstDays[i + 1])),
+          this.opts.day - 1
+        )
 
-        if (d.year === year) {
+        if (d.getFullYear() === year) {
           this.dates.push(d)
         }
       }

--- a/src/Chinese.js
+++ b/src/Chinese.js
@@ -2,7 +2,7 @@
 
 const CalChinese = require('date-chinese')
 const CalEvent = require('./CalEvent')
-const CalDate = require('caldate')
+const addDays = require('date-fns/add_days')
 
 class Chinese extends CalEvent {
   /**
@@ -32,12 +32,12 @@ class Chinese extends CalEvent {
     if (opts.solarterm) {
       jde = this.cal.solarTerm(opts.solarterm, year)
       date = this.cal.fromJDE(jde).toGregorian()
-      d = new CalDate(date).setOffset(opts.day - 1)
+      d = addDays(new Date(date.year, date.month - 1, date.day), opts.day - 1)
     } else {
       this.cal.set(opts.cycle, opts.year, opts.month, opts.leapMonth, opts.day)
       jde = this.cal.toJDE(year)
       date = this.cal.fromJDE(jde).toGregorian()
-      d = new CalDate(date)
+      d = new Date(date.year, date.month - 1, date.day)
     }
 
     this.dates.push(d)

--- a/src/Easter.js
+++ b/src/Easter.js
@@ -2,7 +2,8 @@
 
 const easter = require('date-easter')
 const CalEvent = require('./CalEvent')
-const CalDate = require('caldate')
+const addDays = require('date-fns/add_days')
+const addMinutes = require('date-fns/add_minutes')
 
 class Easter extends CalEvent {
   /**
@@ -21,7 +22,8 @@ class Easter extends CalEvent {
   }
 
   inYear (year) {
-    const d = (new CalDate(this._fn(year))).setOffset(this.offset)
+    let d = addDays(new Date(this._fn(year)), this.offset)
+    d = addMinutes(d, new Date().getTimezoneOffset())
     this.dates.push(d)
     return this
   }

--- a/src/Equinox.js
+++ b/src/Equinox.js
@@ -7,6 +7,7 @@ const earth = new planetpos.Planet(require('astronomia/data/vsop87Bearth'))
 
 const {toTimezone} = require('./internal/utils')
 const CalEvent = require('./CalEvent')
+
 const addDays = require('date-fns/add_days')
 const startOfDay = require('date-fns/start_of_day')
 

--- a/src/Equinox.js
+++ b/src/Equinox.js
@@ -5,9 +5,10 @@ const julian = require('astronomia/lib/julian')
 const planetpos = require('astronomia/lib/planetposition')
 const earth = new planetpos.Planet(require('astronomia/data/vsop87Bearth'))
 
-const moment = require('moment-timezone')
+const {toTimezone} = require('./internal/utils')
 const CalEvent = require('./CalEvent')
-const CalDate = require('caldate')
+const addDays = require('date-fns/add_days')
+const startOfDay = require('date-fns/start_of_day')
 
 class Equinox extends CalEvent {
   /**
@@ -45,20 +46,9 @@ class Equinox extends CalEvent {
     }
 
     const str = new julian.Calendar().fromJDE(jde).toDate().toISOString()
-    let date
-    if (/^[+-]\d{2}:\d{2}?$/.test(this._timezone)) { // for '+08:00' formats
-      date = moment(str).utcOffset(this._timezone)
-    } else { // for 'Asia/Shanghai' formats
-      date = moment(str).tz(this._timezone) // move to timezone
-    }
+    const date = toTimezone(new Date(str), this._timezone) // move to timezone
 
-    const floorDate = {
-      year: year,
-      month: date.month() + 1,
-      day: date.date()
-    }
-
-    const d = new CalDate(floorDate).setOffset(this.offset)
+    const d = addDays(startOfDay(date), this.offset)
     this.dates.push(d)
     return this
   }

--- a/src/Hebrew.js
+++ b/src/Hebrew.js
@@ -3,9 +3,10 @@
 const CalEventMap = require('./CalEventMap')
 const calendar = require('./internal/hebrew-calendar')
 const {toTimezone} = require('./internal/utils')
-const format = require('date-fns/format')
+
 const addDays = require('date-fns/add_days')
 const addHours = require('date-fns/add_hours')
+const format = require('date-fns/format')
 
 class Hebrew extends CalEventMap {
   constructor (opts) {

--- a/src/Hebrew.js
+++ b/src/Hebrew.js
@@ -2,6 +2,10 @@
 
 const CalEventMap = require('./CalEventMap')
 const calendar = require('./internal/hebrew-calendar')
+const {toTimezone} = require('./internal/utils')
+const format = require('date-fns/format')
+const addDays = require('date-fns/add_days')
+const addHours = require('date-fns/add_hours')
 
 class Hebrew extends CalEventMap {
   constructor (opts) {
@@ -11,10 +15,11 @@ class Hebrew extends CalEventMap {
 
   get (timezone) {
     const arr = this.dates.map((date) => {
+      const _date = addHours(date, -6)
       const o = {
-        date: date.toString() + ' -0600',
-        start: date.setOffset(-6, 'h').toTimezone(timezone),
-        end: date.toEndDate().toTimezone(timezone)
+        date: format(date, 'YYYY-MM-DD HH:mm:ss -0600'),
+        start: toTimezone(_date, timezone),
+        end: toTimezone(addDays(_date, 1), timezone)
       }
       this._addSubstitute(date, o)
       return o

--- a/src/Hijri.js
+++ b/src/Hijri.js
@@ -2,6 +2,10 @@
 
 const CalEventMap = require('./CalEventMap')
 const calendar = require('./internal/hijri-calendar')
+const {toTimezone} = require('./internal/utils')
+const format = require('date-fns/format')
+const addDays = require('date-fns/add_days')
+const addHours = require('date-fns/add_hours')
 
 class Hijri extends CalEventMap {
   constructor (opts) {
@@ -11,10 +15,11 @@ class Hijri extends CalEventMap {
 
   get (timezone) {
     const arr = this.dates.map((date) => {
+      const _date = addHours(date, -6)
       const o = {
-        date: date.toString() + ' -0600',
-        start: date.setOffset(-6, 'h').toTimezone(timezone),
-        end: date.toEndDate().toTimezone(timezone)
+        date: format(date, 'YYYY-MM-DD HH:mm:ss -0600'),
+        start: toTimezone(_date, timezone),
+        end: toTimezone(addDays(_date, 1), timezone)
       }
       this._addSubstitute(date, o)
       return o

--- a/src/Hijri.js
+++ b/src/Hijri.js
@@ -3,9 +3,10 @@
 const CalEventMap = require('./CalEventMap')
 const calendar = require('./internal/hijri-calendar')
 const {toTimezone} = require('./internal/utils')
-const format = require('date-fns/format')
+
 const addDays = require('date-fns/add_days')
 const addHours = require('date-fns/add_hours')
+const format = require('date-fns/format')
 
 class Hijri extends CalEventMap {
   constructor (opts) {

--- a/src/Julian.js
+++ b/src/Julian.js
@@ -2,7 +2,7 @@
 
 const julian = require('astronomia/lib/julian')
 const CalEvent = require('./CalEvent')
-const CalDate = require('caldate')
+const addDays = require('date-fns/add_days')
 
 class Julian extends CalEvent {
   inYear (year) {
@@ -10,7 +10,7 @@ class Julian extends CalEvent {
       return this
     }
     const cal = new julian.CalendarJulian(year, this.opts.month, this.opts.day).toGregorian()
-    const d = (new CalDate(cal)).setOffset(this.offset)
+    const d = addDays(new Date(cal.year, cal.month - 1, cal.day), this.offset)
     this.dates.push(d)
     return this
   }

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const addHours = require('date-fns/add_hours')
+const addMinutes = require('date-fns/add_minutes')
+
 /**
  * {
  *   0: 'sunday', ...
@@ -91,4 +94,20 @@ exports.toDate = function toDate (str, isUTC) {
       return new Date(year, month - 1, day)
     }
   }
+}
+
+exports.toTimezone = function toTimezone (str, timezone = Intl.DateTimeFormat().resolvedOptions().timeZone) {
+  let date
+  if (/^[+-]\d{2}:\d{2}?$/.test(timezone)) {
+    const timezoneParts = timezone.split(':')
+    const hours = Number.parseInt(timezoneParts[0])
+    const minutes = Number.parseInt(timezoneParts[1]) + new Date().getTimezoneOffset()
+    date = addMinutes(addHours(new Date(str), hours), minutes)
+  } else {
+    date = new Date(
+      new Date(str).toLocaleString('en-US', { timeZone: timezone })
+    )
+  }
+
+  return date
 }

--- a/test/DateFn.mocha.js
+++ b/test/DateFn.mocha.js
@@ -628,7 +628,7 @@ describe('#DateFn', function () {
         end: 'tue 2018-01-09 00:00',
         substitute: true
       }]
-      // log(fixResult(res))
+      // console.log(fixResult(res))
       assert.deepEqual(fixResult(res), exp)
     })
     it('01-01 and if monday then next monday for 2017', function () {

--- a/test/DateFn.mocha.js
+++ b/test/DateFn.mocha.js
@@ -628,7 +628,7 @@ describe('#DateFn', function () {
         end: 'tue 2018-01-09 00:00',
         substitute: true
       }]
-      // console.log(fixResult(res))
+      // log(fixResult(res))
       assert.deepEqual(fixResult(res), exp)
     })
     it('01-01 and if monday then next monday for 2017', function () {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -25,17 +25,6 @@ exports.fixResult = function fixResult (arr) {
   })
 }
 
-// function toString (date) {
-//   var year = pad0(date.getFullYear(), 4)
-//   var month = pad0(date.getMonth() + 1)
-//   var day = pad0(date.getDate())
-//   var hours = pad0(date.getHours())
-//   var minutes = pad0(date.getMinutes())
-//   var seconds = pad0(date.getSeconds())
-//
-//   return year + '-' + month + '-' + day + ' ' + hours + ':' + minutes + ':' + seconds
-// }
-
 exports.moveToTimezone = function (date, timezone) {
   if (!timezone) {
     return date

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const moment = require('moment-timezone')
-const pad0 = require('../src/internal/utils').pad0
+const {pad0, toTimezone} = require('../src/internal/utils')
 
 const toIso = exports.toIso = function toIso (date) {
+  date = new Date(date)
   var days = 'sun,mon,tue,wed,thu,fri,sat'.split(',')
 
   var y = pad0(date.getFullYear(), 4)
@@ -25,22 +25,22 @@ exports.fixResult = function fixResult (arr) {
   })
 }
 
-function toString (date) {
-  var year = pad0(date.getFullYear(), 4)
-  var month = pad0(date.getMonth() + 1)
-  var day = pad0(date.getDate())
-  var hours = pad0(date.getHours())
-  var minutes = pad0(date.getMinutes())
-  var seconds = pad0(date.getSeconds())
-
-  return year + '-' + month + '-' + day + ' ' + hours + ':' + minutes + ':' + seconds
-}
+// function toString (date) {
+//   var year = pad0(date.getFullYear(), 4)
+//   var month = pad0(date.getMonth() + 1)
+//   var day = pad0(date.getDate())
+//   var hours = pad0(date.getHours())
+//   var minutes = pad0(date.getMinutes())
+//   var seconds = pad0(date.getSeconds())
+//
+//   return year + '-' + month + '-' + day + ' ' + hours + ':' + minutes + ':' + seconds
+// }
 
 exports.moveToTimezone = function (date, timezone) {
   if (!timezone) {
     return date
   }
-  return new Date(moment.tz(toString(date), timezone).format())
+  return toTimezone(date, timezone).toString()
 }
 
 function localDate (str) {


### PR DESCRIPTION
We've found date-holidays to be a very useful package, with one downside being `moment` inflating bundle size significantly. This PR removes the `moment` dependencies (as well as `caldate`) and replaces it with vanilla JS and [date-fns](https://github.com/date-fns/date-fns) where appropriate.

For our main use case, these dependencies were taking up more than 40% of the size of our vendor bundle (180kB for `moment-timezone` and 56kB for `moment`, for a combined 236kB).

`date-fns` is highly modularised. The usage here is for 42kB for us (it may be less as some of our entrypoints might be pulling other date-fns modules not used in this PR into our vendor bundle).

---

RE the implementation of `toTimezone` in `internal/utils.js` and browser support for the `timeZone` setting of [Date.prototype.toLocaleString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString):
- :white_check_mark: Chrome: Supported since 24 
- :white_check_mark: Firefox: Supported since 52
- :white_check_mark: Safari 10+: Supported
- ❓Edge: ?
- :x: IE11: Only accepts 'UTC' and complains for anything else
- :x: IE10: Ignored completely (uses local system time)

There is a polyfill here which could be used when necessary. https://github.com/yahoo/date-time-format-timezone