### PR TITLE
Type checking before using substr

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -212,7 +212,9 @@ class Parser {
   }
 
   _shorten (o, cap0) {
-    o.str = o.str.substr(cap0.length, o.str.length)
+    if(typeof o.str === 'string') {
+      o.str = o.str.substr(cap0.length, o.str.length)
+    }
   }
 
   _date (o) {


### PR DESCRIPTION
I am using the plugin date-holidays@1.3.6 (which uses date-holidays-parser@1.3.1) within an Ionic 3 App.
While using, the plugin throws the error `o.str.substr is not a function` and stops working.
That happens because o.str can have an other datatypes than string.
While debugging I've seen, that `o.str` is a `function` sometimes and not a `string` for some reason.
So it's obviously not possible to call `substr` on a function.
In this PR I've added a typecheck before using `substr`.