### PR TITLE
Return rule in getHolidays

### DIFF
--- a/src/Holidays.js
+++ b/src/Holidays.js
@@ -169,7 +169,7 @@ Holidays.prototype = {
     Object.keys(this.holidays).forEach((rule) => {
       if (this.holidays[rule].fn) {
         this._dateByRule(year, rule).forEach((o) => {
-          arr.push(this._translate(o, langs))
+          arr.push({ ...this._translate(o, langs), rule: rule })
         })
       }
     })


### PR DESCRIPTION
This changes getHolidays such that the rule is returned alongside the date and name.

Use case: I need to make a translatable selection input of holidays. The rule is the only constant when years and language vary. This seemed to be the easiest fix.