### PR TITLE
fix: parsing rule for solstice, equinox

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -50,7 +50,7 @@ const grammar = (function () {
 
     julian: /^julian date/,
     easter: /^(easter|orthodox)(?: _count_days)?/,
-    equinox: /^([Mm]arch|[Jj]une|[Ss]eptember|[Dd]ecember) (?:equinox|solstice)?(?:_timezone)?/,
+    equinox: /^([Mm]arch|[Jj]une|[Ss]eptember|[Dd]ecember) (?:equinox|solstice)(?:_timezone)?/,
     hebrew: /^0?(\d{1,2}) (_hebrewMonths)(?: 0*(\d{1,}))?/,
     islamic: /^0?(\d{1,2}) (_islamicMonths)(?: 0*(\d{1,}))?/,
     chineseLunar: /^(chinese|korean|vietnamese) (?:(\d+)-(\d{1,2})-)?(\d{1,2})-([01])-(\d{1,2})/,

--- a/test/fixtures/parser.js
+++ b/test/fixtures/parser.js
@@ -811,6 +811,31 @@ module.exports = {
       direction: 'after'
     }
   ],
+  'Monday after 2nd Saturday in September 13:00': [
+    {
+      day: 1,
+      fn: 'gregorian',
+      month: 9,
+      year: undefined
+    },
+    {
+      count: 2,
+      direction: 'after',
+      rule: 'dateDir',
+      weekday: 'saturday'
+    },
+    {
+      count: 1,
+      direction: 'after',
+      rule: 'dateDir',
+      weekday: 'monday'
+    },
+    {
+      hour: 13,
+      minute: 0,
+      rule: 'time'
+    }
+  ],
   '2nd sunday after 05-01 if equal easter 49 then 3rd sunday after 05-01': [
     {
       fn: 'gregorian',


### PR DESCRIPTION
`in September` rule accidentally gets parsed to september equinox.