### PR TITLE
feat: methods to get, set, unset holiday rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "colors": true
   },
   "dependencies": {
-    "astronomia": "^3.0.0",
+    "astronomia": "^3.0.4",
     "caldate": "^2.0.0",
     "date-bengali-revised": "^2.0.0",
     "date-chinese": "^2.0.0",
@@ -67,9 +67,9 @@
     "moment-timezone": "^0.5.33"
   },
   "devDependencies": {
-    "c8": "^7.6.0",
-    "dtslint": "^4.0.8",
-    "eslint": "^7.23.0",
+    "c8": "^7.7.1",
+    "dtslint": "^4.0.9",
+    "eslint": "^7.25.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
@@ -78,9 +78,9 @@
     "mocha": "^8.3.2",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
-    "rollup": "^2.43.0",
+    "rollup": "^2.46.0",
     "serialize-to-module": "^1.1.0",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.4"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/src/CalEvent.js
+++ b/src/CalEvent.js
@@ -44,7 +44,7 @@ export default class CalEvent {
    * @param {Object[]} active - definition of active ranges `{from: {Date}, [to]: {Date}}`
    * @return {this} for chaining
    */
-  filter (year, active = this.active) {
+  filterActive (year, active = this.active) {
     this.dates = this.dates.filter((date) => {
       if (!date._filter && isActive(date, year, active)) {
         return date

--- a/src/CalEvent.js
+++ b/src/CalEvent.js
@@ -40,6 +40,27 @@ export default class CalEvent {
   }
 
   /**
+   * Filter out disabled dates
+   * @param {number} year
+   * @param {number} month
+   * @returns {this}
+   */
+  filterDisabled (year, month) {
+    if (!year) {
+      return this
+    }
+
+    this.dates = this.dates.filter((date) => {
+      const disable = month
+        ? date.year === year && date.month === month
+        : date.year === year
+      return !disable
+    })
+
+    return this
+  }
+
+  /**
    * @param {Number} year - year to filter
    * @param {Object[]} active - definition of active ranges `{from: {Date}, [to]: {Date}}`
    * @return {this} for chaining
@@ -68,6 +89,8 @@ export default class CalEvent {
     if (pushIt) {
       this.active.push(active)
     }
+
+    return this
   }
 
   push (calEvent) {
@@ -96,11 +119,7 @@ export default class CalEvent {
 
 function isActive (date, year, active) {
   if (!active) {
-    if (date.year === year) {
-      return true
-    } else {
-      return false
-    }
+    return date.year === year
   }
   const _date = date.toDate()
   for (const a of active) {
@@ -108,8 +127,8 @@ function isActive (date, year, active) {
     if (
       date.year === year &&
       ((from && to && from <= _date && to > _date) ||
-      (from && !to && from <= _date) ||
-      (!from && to && to > _date))
+        (from && !to && from <= _date) ||
+        (!from && to && to > _date))
     ) {
       return true
     }

--- a/src/DateFn.js
+++ b/src/DateFn.js
@@ -21,9 +21,15 @@ export default class DateFn {
     this.holidays = holidays
     this.opts = holidays ? holidays[ruleStr] : {}
     this.event = undefined
+    this.cache = new Map()
   }
 
   inYear (year) {
+    if (this.cache.has(year)) {
+      this.event = this.cache.get(year)
+      return this
+    }
+
     let ruleFn // current rule
     const postProc = new PostRule(this.ruleStr, this.opts, this.holidays)
 
@@ -43,7 +49,10 @@ export default class DateFn {
       }
     })
 
-    this.event = postProc.getEvent(year)
+    const event = postProc.getEvent(year)
+    this.cache.set(year, event)
+
+    this.event = event
     return this
   }
 

--- a/src/HolidayRule.js
+++ b/src/HolidayRule.js
@@ -2,7 +2,7 @@ import { toNumber } from './internal/utils.js'
 
 /**
  * Holiday Rule
- * Apart from `rule` and `name` other optionals
+ * Apart from `rule` and `name` other options may be set
  * @constructor
  * @param {object} ruleObj
  * @param {string} ruleObj.rule - the rule string

--- a/src/HolidayRule.js
+++ b/src/HolidayRule.js
@@ -1,0 +1,33 @@
+import { toNumber } from './internal/utils.js'
+
+/**
+ * Holiday Rule
+ * Apart from `rule` and `name` other optionals
+ * @constructor
+ * @param {object} ruleObj
+ * @param {string} ruleObj.rule - the rule string
+ * @param {string|object} [ruleObj.name] - the name of the holiday, plain or with i18n
+ * @param {string} [ruleObj.type] - type of holiday
+ * @param {boolean} [ruleObj.substitute] - substitute holiday
+ * @param {object[]} [ruleObj.active] - active `[{from?: str, to?: str}]`
+ */
+export class HolidayRule {
+  constructor (ruleObj) {
+    const { rule, fn, opts, ...other } = ruleObj
+    Object.assign(this, { rule, ...other })
+  }
+
+  /**
+   * disable rule in year (month)
+   * @param {number} year
+   * @param {number} [month] - 1..12
+   */
+  disableIn (year, month) {
+    if (!toNumber(year)) return
+    month = month < 1 && month > 12
+      ? undefined
+      : month < 10 ? '0' + Number(month) : month
+    const dateStr = [year, month].filter(Boolean).join('-')
+    this.disable = (this.disable || []).concat(dateStr).sort()
+  }
+}

--- a/src/Holidays.js
+++ b/src/Holidays.js
@@ -190,7 +190,7 @@ export class Holidays {
 
   /**
    * check whether `date` is a holiday or not
-   * @param {Date} [date]
+   * @param {Date|String} [date]
    * @return {Array<Holiday>|false} holiday:
    * ```
    * {String} date - ISO Date String of (start)-date in local format
@@ -201,7 +201,7 @@ export class Holidays {
    * ```
    */
   isHoliday (date) {
-    date = date || new Date()
+    date = date ? new Date(date) : new Date()
     const d = new CalDate()
     d.fromTimezone(date, this.__timezone)
     const year = d.year

--- a/src/Holidays.js
+++ b/src/Holidays.js
@@ -54,7 +54,7 @@ export class Holidays {
 
     // reset settings
     this.__conf = null
-    this.__types = opts.types?.length ? opts.types : TYPES
+    this.__types = opts.types && opts.types.length ? opts.types : TYPES
     this.holidays = {}
     this.setLanguages()
 

--- a/src/PostRule.js
+++ b/src/PostRule.js
@@ -25,7 +25,7 @@ export default class PostRule {
     const active = this.ruleSet && this.ruleSet.active
     this.disable(year)
     const ev = this.events[0]
-    ev.filter(year, active)
+    ev.filterActive(year, active)
     return ev
   }
 

--- a/src/PostRule.js
+++ b/src/PostRule.js
@@ -1,7 +1,6 @@
 
-import { get as _get } from './utils.js'
+import { get as _get, toNumber } from './utils.js'
 import CalEvent from './CalEvent.js'
-import Parser from './Parser.js'
 
 export default class PostRule {
   /**
@@ -71,25 +70,45 @@ export default class PostRule {
   }
 
   disable (year) {
+    const { disable, enable } = this.opts || {}
+    if (!disable?.length) return
+
     const ev = this.events[0]
-    let tmpEv = this._findEventInYear(year, this.opts.disable)
+
+    // check if exact event was disabled or moved
+    let tmpEv = _findEventInYear(year, disable)
     if (tmpEv) {
       if (tmpEv.isEqualDate(ev)) {
         ev.reset()
-        tmpEv = this._findEventInYear(year, this.opts.enable)
+        tmpEv = _findEventInYear(year, enable)
         if (tmpEv) this.events[0] = tmpEv
       }
+      return
     }
-  }
 
-  _findEventInYear (year, arr) {
-    arr = arr || []
-    const parser = new Parser()
-    for (const item of arr) {
-      const p = parser.parse(item)
-      if (p && p[0] && p[0].year && p[0].year === year) {
-        return new CalEvent(p[0]).inYear(p[0].year)
-      }
+    // simply check if the event can be disabled for year-(month)
+    const [_year, _month] = _findDisabled(year, disable)
+    ev.filterDisabled(_year, _month)
+  }
+}
+
+const isoDate = (isoDateStr) => String(isoDateStr).split('-').map(v => toNumber(v))
+
+function _findEventInYear (_year, arr = []) {
+  for (const item of arr) {
+    const [year, month, day] = isoDate(item)
+    if (year === _year && month && day) {
+      return new CalEvent({ year, month, day }).inYear(year)
     }
   }
+}
+
+function _findDisabled (_year, arr = []) {
+  for (const isoDateStr of arr) {
+    const [year, month] = isoDate(isoDateStr)
+    if (_year === year) {
+      return [year, month]
+    }
+  }
+  return []
 }

--- a/src/PostRule.js
+++ b/src/PostRule.js
@@ -71,7 +71,7 @@ export default class PostRule {
 
   disable (year) {
     const { disable, enable } = this.opts || {}
-    if (!disable?.length) return
+    if (!disable || !disable.length) return
 
     const ev = this.events[0]
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export { Holidays as default } from './Holidays.js'
+export * from './HolidayRule.js'

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,6 +48,11 @@ export const omit = (object, props = []) => Object.keys(object)
 
 export const merge = (...args) => deepmerge.all(args)
 
+export const toNumber = (num, def) => {
+  const _num = Number(num)
+  return isNaN(_num) ? def : _num
+}
+
 export default {
   get,
   set,

--- a/test/CalEvent.mocha.js
+++ b/test/CalEvent.mocha.js
@@ -7,6 +7,7 @@ import Equinox from '../src/Equinox.js'
 import Easter from '../src/Easter.js'
 import Hebrew from '../src/Hebrew.js'
 import Hijri from '../src/Hijri.js'
+import CalDate from 'caldate'
 
 describe('#CalEventFactory', function () {
   it('12-03', function () {
@@ -174,6 +175,52 @@ describe('#CalEvent', function () {
     ]
     // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
+  })
+
+  it('can reset events', function () {
+    const ev = new CalEvent({ month: 12, day: 2 })
+      .inYear(2015)
+      .inYear(2016)
+
+    assert.strictEqual(ev.dates.length, 2)
+    ev.reset()
+    assert.strictEqual(ev.dates.length, 0)
+  })
+
+  it('filter active dates for 2015 without active range', function () {
+    const ev = new CalEvent({ month: 12, day: 2 })
+      .inYear(2014)
+      .inYear(2015)
+      .filterActive(2015)
+    assert.deepStrictEqual(ev.dates, [new CalDate({ year: 2015, month: 12, day: 2 })])
+  })
+
+  it('filter active dates for 2014', function () {
+    const ev = new CalEvent({ month: 12, day: 2 })
+      .inYear(2014)
+      .inYear(2015)
+      .setActive({ from: new Date('2015-01-01'), to: new Date('2015-12-31') })
+      .filterActive(2014)
+    console.log(ev)
+    assert.deepStrictEqual(ev.dates, [])
+  })
+
+  it('filter active dates for 2015', function () {
+    const ev = new CalEvent({ month: 12, day: 2 })
+      .inYear(2014)
+      .inYear(2015)
+      .setActive({ from: new Date('2015-01-01'), to: new Date('2015-12-31') })
+      .filterActive(2015)
+    assert.deepStrictEqual(ev.dates, [new CalDate({ year: 2015, month: 12, day: 2 })])
+  })
+
+  it('shall combine active range', function () {
+    const ev = new CalEvent({ month: 12, day: 2 })
+      .setActive({ from: new Date('2014-01-01') })
+      .setActive({ to: new Date('2014-12-31') })
+    assert.deepStrictEqual(ev.active, [
+      { from: new Date('2014-01-01'), to: new Date('2014-12-31') }
+    ])
   })
 
   describe('filter', function () {

--- a/test/CalEvent.mocha.js
+++ b/test/CalEvent.mocha.js
@@ -183,7 +183,7 @@ describe('#CalEvent', function () {
         const exp = test.exp
         it('in year ' + year, function () {
           const date = new CalEvent(event)
-          date.inYear(year).filter(year, active)
+          date.inYear(year).filterActive(year, active)
           const res = date.get()
           assert.strictEqual(res.length, exp.length)
           if (exp.length) {

--- a/test/HolidayRule.mocha.js
+++ b/test/HolidayRule.mocha.js
@@ -1,0 +1,36 @@
+import assert from 'assert'
+import { HolidayRule } from '../src/index.js'
+
+describe('HolidayRule', function () {
+  it('shall create a rule', function () {
+    const rule = new HolidayRule({ rule: '05-01', type: 'public' })
+    assert.strictEqual(rule.rule, '05-01')
+    assert.strictEqual(rule.type, 'public')
+  })
+
+  it('shall disable rule for 2020 and 2018', function () {
+    const rule = new HolidayRule({ rule: '05-01', type: 'public' })
+    rule.disableIn(2020)
+    rule.disableIn(2018)
+    assert.strictEqual(rule.rule, '05-01')
+    assert.strictEqual(rule.type, 'public')
+    assert.deepStrictEqual(rule.disable, ['2018', '2020'])
+  })
+
+  it('shall disable rule for 2020-01 and 2018-12', function () {
+    const rule = new HolidayRule({ rule: '05-01', type: 'public' })
+    rule.disableIn(2020, 1)
+    rule.disableIn(2018, 12)
+    assert.strictEqual(rule.rule, '05-01')
+    assert.strictEqual(rule.type, 'public')
+    assert.deepStrictEqual(rule.disable, ['2018-12', '2020-01'])
+  })
+
+  it('shall silently ignore undefined year', function () {
+    const rule = new HolidayRule({ rule: '05-01', type: 'public' })
+    rule.disableIn()
+    assert.strictEqual(rule.rule, '05-01')
+    assert.strictEqual(rule.type, 'public')
+    assert.strictEqual(rule.disable, undefined)
+  })
+})

--- a/test/Holidays.mocha.js
+++ b/test/Holidays.mocha.js
@@ -590,9 +590,8 @@ describe('#Holidays', function () {
       assert.strictEqual(toIso(res.end), 'tue 2016-12-06 00:00')
     })
   })
-
   describe('custom data', function () {
-    it('can get list of holidays', function () {
+    it('can get list of holidays together with custom attributes', function () {
       const hd = new Holidays(fixtures.custom, 'custom')
       const exp = [
         {
@@ -601,7 +600,8 @@ describe('#Holidays', function () {
           end: localDate('2017-01-02 00:00'),
           name: 'New Year',
           type: 'public',
-          rule: '01-01'
+          rule: '01-01',
+          payroll: 2
         },
         {
           date: '2017-05-01 00:00:00',
@@ -609,7 +609,8 @@ describe('#Holidays', function () {
           end: localDate('2017-05-06 00:00'),
           name: 'Laybour Day',
           type: 'public',
-          rule: '05-01 P5D'
+          rule: '05-01 P5D',
+          payroll: 1.5
         },
         {
           date: '2017-12-25 00:00:00',

--- a/test/Holidays.mocha.js
+++ b/test/Holidays.mocha.js
@@ -667,7 +667,7 @@ describe('#Holidays', function () {
 
       assert.deepStrictEqual(rule, exp)
       assert.deepStrictEqual(hd.isHoliday('2020-11-26T05:00:00Z'), false)
-      assert.strictEqual(hd.isHoliday('2021-11-25T05:00:00Z')?.[0]?.name, 'Thanksgiving Day')
+      assert.strictEqual(hd.isHoliday('2021-11-25T05:00:00Z')[0].name, 'Thanksgiving Day')
     })
   })
 })

--- a/test/Holidays.mocha.js
+++ b/test/Holidays.mocha.js
@@ -1,7 +1,7 @@
 // import 'core-js/es6/index.js' // for IE11
 
 import assert from 'assert'
-import Holidays from '../src/index.js'
+import Holidays, { HolidayRule } from '../src/index.js'
 import { toIso, localDate, moveToTimezone } from './helpers.js'
 
 import fixtures from './fixtures/index.cjs'
@@ -622,6 +622,51 @@ describe('#Holidays', function () {
       ]
       const list = hd.getHolidays(2017)
       assert.deepStrictEqual(list, exp)
+    })
+  })
+
+  describe('get, set rule', function () {
+    it('gets holiday rules', function () {
+      const hd = new Holidays(fixtures.holidays, { country: 'US' })
+      const rulesList = hd.getRules()
+      const exp = new HolidayRule({
+        rule: '4th thursday in November',
+        name: { en: 'Thanksgiving Day' },
+        type: 'public'
+      })
+      // console.log(rulesList.map((rule, i) => ({i, rule})))
+      assert.deepStrictEqual(rulesList[17], exp)
+    })
+
+    it('get holiday rule for "4th thursday in November"', function () {
+      const hd = new Holidays(fixtures.holidays, { country: 'US' })
+      const rule = hd.getRule('4th thursday in November')
+      const exp = new HolidayRule({
+        rule: '4th thursday in November',
+        name: { en: 'Thanksgiving Day' },
+        type: 'public'
+      })
+      assert.deepStrictEqual(rule, exp)
+    })
+
+    it('disable holiday rule for "4th thursday in November" for 2020', function () {
+      const hd = new Holidays(fixtures.holidays, { country: 'US' })
+      const rule = hd.getRule('4th thursday in November')
+      rule.disableIn(2020)
+      hd.setRule(rule)
+
+      const exp = new HolidayRule({
+        rule: '4th thursday in November',
+        name: { en: 'Thanksgiving Day' },
+        type: 'public',
+        disable: [
+          '2020'
+        ]
+      })
+
+      assert.deepStrictEqual(rule, exp)
+      assert.deepStrictEqual(hd.isHoliday('2020-11-26T05:00:00Z'), false)
+      assert.strictEqual(hd.isHoliday('2021-11-25T05:00:00Z')?.[0]?.name, 'Thanksgiving Day')
     })
   })
 })

--- a/test/fixtures/custom.json
+++ b/test/fixtures/custom.json
@@ -11,12 +11,14 @@
         "01-01": {
           "name": {
             "en": "New Year"
-          }
+          },
+          "payroll": 2
         },
         "05-01 P5D": {
           "name": {
             "en": "Laybour Day"
-          }
+          },
+          "payroll": 1.5
         },
         "12-25": {
           "name": {

--- a/test/fixtures/custom.yaml
+++ b/test/fixtures/custom.yaml
@@ -11,9 +11,11 @@ holidays:
       01-01:
         name:
           en: New Year
+        payroll: 2
       05-01 P5D:
         name:
           en: Laybour Day
+        payroll: 1.5
       12-25:
         name:
           en: Christmas

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,90 +1,208 @@
 declare module 'date-holidays-parser' {
-    namespace Holidays {
-        export interface Country {
-            country: string;
-            state?: string;
-            region?: string;
-        }
-
-        export type HolidayType = 'public' | 'bank' | 'school' | 'observance';
-
-        export interface Options {
-            languages?: string | string[];
-            timezone?: string;
-            types?: HolidayType[];
-        }
-
-        export interface HolidayOptions {
-            name: { [key: string]: string; };
-            type: HolidayType;
-        }
-
-        export interface Holiday {
-            date: string;
-            start: Date;
-            end: Date;
-            name: string;
-            type: HolidayType;
-            rule: string;
-            substitute?: boolean;
-        }
-
-        export interface HolidaysInterface {
-            init(country?: Country | string, opts?: Options): void;
-
-            init(country?: string, state?: string, opts?: Options): void;
-
-            init(country?: string, state?: string, region?: string, opts?: Options): void;
-
-            setHoliday(rule: string, opts: HolidayOptions | string): boolean;
-
-            getHolidays(year?: string | number | Date, lang?: string): Holiday[];
-
-            isHoliday(date: Date): Holiday[] | false;
-
-            query(country?: string, state?: string, lang?: string): { [key: string]: string; };
-
-            getCountries(lang?: string): { [key: string]: string; };
-
-            getStates(country: string, lang?: string): { [key: string]: string; };
-
-            getRegions(country: string, state: string, lang?: string): { [key: string]: string; };
-
-            getTimezones(): string[];
-
-            setTimezone(timezone: string): void;
-
-            getLanguages(): string[];
-
-            setLanguages(language: string | string[]): string[];
-
-            getDayOff(): string;
-        }
+  namespace Holidays {
+    export interface Country {
+      /** IANA country code */
+      country: string;
+      /** short code of state (ISO 3166-2) */
+      state?: string;
+      /** short code of region */
+      region?: string;
     }
 
-    class Holidays implements Holidays.HolidaysInterface {
-        constructor(opts?: Holidays.Options);
-        constructor(country: Holidays.Country | string, opts?: Holidays.Options);
-        constructor(country: Holidays.Country | string, state: string, opts?: Holidays.Options);
-        constructor(country: Holidays.Country | string, state: string, region: string, opts?: Holidays.Options);
+    export type HolidayType = 'public' | 'bank' | 'optional' | 'school' | 'observance' | string;
 
-        // HolidaysInterface:
-        init(country?: Holidays.Country | string, opts?: Holidays.Options): void;
-        init(country?: string, state?: string, opts?: Holidays.Options): void;
-        init(country?: string, state?: string, region?: string, opts?: Holidays.Options): void;
-        setHoliday(rule: string, opts: Holidays.HolidayOptions | string): boolean;
-        getHolidays(year?: string | number | Date, lang?: string): Holidays.Holiday[];
-        isHoliday(date: Date): Holidays.Holiday[] | false;
-        query(country?: string, state?: string, lang?: string): { [key: string]: string; };
-        getCountries(lang?: string): { [key: string]: string; };
-        getStates(country: string, lang?: string): { [key: string]: string; };
-        getRegions(country: string, state: string, lang?: string): { [key: string]: string; };
-        getTimezones(): string[];
-        setTimezone(timezone: string): void;
-        getLanguages(): string[];
-        setLanguages(language: string | string[]): string[];
-        getDayOff(): string;
+    export interface Options {
+      /** languages using ISO 639-1 shortcodes */
+      languages?: string | string[];
+      /** timezone, e.g. America/New_York */
+      timezone?: string;
+      /**
+       * holiday types; priority is in ascending order (low ... high)
+       * default ['observance', 'optional', 'school', 'bank', 'public']
+       */
+      types?: HolidayType[];
     }
 
-    export = Holidays;
+    export interface ActiveRange {
+      /** active from date */
+      from?: Date | string;
+      /** active until date */
+      to?: Date | string;
+    }
+
+    export interface HolidayOptions {
+      /** holiday name or if object holiday names in different languages. key defines language */
+      name: { [key: string]: string; } | string;
+      /** holiday type */
+      type?: HolidayType;
+      /** disable rule in year, year+month or date */
+      disabled?: string[];
+      /** enable a different date; requires disabled date for given year */
+      enabled?: string[];
+      /** defines active ranges of rule */
+      active?: ActiveRange[];
+      /** substitute a holiday */
+      substitute?: boolean;
+      /** custom attributes */
+      [key: string]: any;
+    }
+
+    export interface HolidayRule extends HolidayOptions {
+      /** the holiday rule */
+      rule: string;
+    }
+
+    export interface Holiday {
+      /** datestring as "YYYY-MM-DD hh:mm:ss [-hh:ss]" */
+      date: string;
+      /** start date */
+      start: Date;
+      /** end date */
+      end: Date;
+      /** name of holiday in selected or fallback language */
+      name: string;
+      /** type of holiday */
+      type: HolidayType;
+      /** the holiday rule - use for references */
+      rule: string;
+      /** holiday is a substritute day */
+      substitute?: boolean;
+    }
+  }
+
+  export class HolidayRule {
+    constructor(ruleObj: Holidays.HolidayRule);
+    /**
+     * disable rule in year (month)
+     */
+    disableIn(year: number, month?: number): void;
+  }
+
+  export default class Holidays {
+    constructor(data: object, opts?: Holidays.Options);
+    constructor(data: object, country: Holidays.Country | string, opts?: Holidays.Options);
+    constructor(data: object, country: Holidays.Country | string, state: string, opts?: Holidays.Options);
+    constructor(data: object, country: Holidays.Country | string, state: string, region: string, opts?: Holidays.Options);
+
+    /**
+     * initialize holidays for a country/state/region
+     */
+    init(country?: Holidays.Country | string, opts?: Holidays.Options): void;
+    init(country?: string, state?: string, opts?: Holidays.Options): void;
+    init(country?: string, state?: string, region?: string, opts?: Holidays.Options): void;
+
+    /**
+     * set (custom) holiday
+     * @throws {TypeError}
+     * @param rule - rule for holiday (check supported grammar) or date in ISO Format, e.g. 12-31 for 31th Dec
+     * @param [opts] - holiday options, if String then opts is used as name
+     * @param opts.name - translated holiday names e.g. `{ en: 'name', es: 'nombre', ... }`
+     * @param opts.type - holiday type `public|bank|school|observance`
+     * @returns `true` if holiday could be set returns `true`
+     */
+    setHoliday(rule: string, opts: Holidays.HolidayOptions | string): boolean;
+    /**
+     * get all holidays for `year` with names using prefered `language`
+     * @param [year] - if omitted current year is choosen
+     * @param [language] - ISO 639-1 code for language
+     * @returns of found holidays in given year sorted by Date:
+     */
+    getHolidays(year?: string | number | Date, lang?: string): Holidays.Holiday[];
+    /**
+     * check whether `date` is a holiday or not
+     * @returns of found holidays in given year sorted by Date:
+     */
+    isHoliday(date: Date|string): Holidays.Holiday[] | false;
+
+    /**
+     * set or update rule
+     * @returns `true` if holiday could be set returns `true`
+     */
+    setRule(holidayRule: HolidayRule|object): boolean;
+    /**
+     * unset rule
+     * @param rule - rule for holiday (check supported grammar) or date in ISO Format, e.g. 12-31 for 31th Dec
+     * @returns `true` if holiday could be set returns `true`
+     */
+    unsetRule(rule: string): boolean;
+    /**
+     * get available rules for selected country, (state, region)
+     */
+    getRules(): HolidayRule[];
+    /**
+     * get rule for selected country, (state, region)
+     * @param rule - rule for holiday (check supported grammar) or date in ISO Format, e.g. 12-31 for 31th Dec
+     */
+    getRule(rule: string): HolidayRule;
+
+    /**
+     * Query for available Countries, States, Regions
+     * @param [country] - country code
+     * @param [state] - state code
+     * @param [lang] - ISO-639 language shortcode
+     * @returns shortcode, name pairs of supported countries, states, regions
+     */
+    query(country?: string, state?: string, lang?: string): { [key: string]: string; };
+    /**
+     * get supported countries
+     * @param [lang] - ISO-639 language shortcode
+     * @returns shortcode, name pairs of supported countries
+     * ```js
+     * { AD: 'Andorra',
+     *   US: 'United States' }
+     * ```
+     */
+    getCountries(lang?: string): { [key: string]: string; };
+    /**
+     * get supported states for a given country
+     * @param country - shortcode of country
+     * @param [lang] - ISO-639 language shortcode
+     * @returns shortcode, name pairs of supported states, regions
+     * ```js
+     * { al: 'Alabama', ...
+     *   wy: 'Wyoming' }
+     * ```
+     */
+    getStates(country: string, lang?: string): { [key: string]: string; };
+    /**
+     * get supported regions for a given country, state
+     * @param country - shortcode of country
+     * @param state - shortcode of state
+     * @param [lang] - ISO-639 language shortcode
+     * @returns shortcode, name pairs of supported regions
+     * ```js
+     * { no: 'New Orleans' }
+     * ```
+     */
+    getRegions(country: string, state: string, lang?: string): { [key: string]: string; };
+
+    /**
+     * sets timezone
+     * @param timezone - see `moment-timezone`
+     * if `timezone` is `undefined` then all dates are considered local dates
+     */
+    setTimezone(timezone: string): void;
+    /**
+     * get timezones for country, state, region
+     * @returns of {String}s containing the timezones
+     */
+    getTimezones(): string[];
+
+    /**
+     * set language(s) for holiday names
+     * @returns set languages
+     */
+    setLanguages(language: string | string[]): string[];
+    /**
+     * get languages for selected country, state, region
+     * @returns containing ISO 639-1 language shortcodes
+     */
+    getLanguages(): string[];
+
+    /**
+     * get default day off as weekday
+     * @returns weekday of day off
+     */
+    getDayOff(): string;
+  }
 }

--- a/types/typings.test.ts
+++ b/types/typings.test.ts
@@ -1,7 +1,40 @@
-import * as Holidays from 'date-holidays-parser';
+import Holidays from 'date-holidays-parser';
 
-const hd = new Holidays('');
+const data = {
+  holidays: {
+    CUSTOM: {
+      name: {
+        en: 'custom'
+      },
+      langs: [
+        'en'
+      ],
+      days: {
+        '01-01': {
+          name: {
+            en: 'New Year'
+          },
+          payroll: 2
+        },
+        '05-01 P5D': {
+          name: {
+            en: 'Laybour Day'
+          },
+          payroll: 1.5
+        },
+        '12-25': {
+          name: {
+            en: 'Christmas'
+          }
+        }
+      }
+    }
+  }
+};
+
+const hd = new Holidays(data);
 hd.init('US');
 
-hd.isHoliday(new Date('2019-06-04')); // $ExpectType false | Holiday[]
+hd.isHoliday(new Date('2019-01-01')); // $ExpectType false | Holiday[]
+hd.isHoliday(new Date('2019-02-01')); // $ExpectType false | Holiday[]
 hd.getHolidays(); // $ExpectType Holiday[]


### PR DESCRIPTION
This PR contains new features to work with holiday rules and fixes the TS typings.

To allow modification of holiday rules new methods to modify those are
introduced.
- setRule() to set new holiday rule
- unsetRule() to unset a holiday rule
- getRules() to get all rules
- getRule() to get a dedicated rule
- new class HolidayRule to allow programmatic disable 

DateFn now caches results by default:
- re-calculations for same year now use the cached values

Typings are fixed:
- Custom attributes are possible 
- Custom holiday types are available
