### PR TITLE
fix(CalEventMap): 2nd date in calendar can't be reached

### DIFF
--- a/scripts/hijri-calendar/index.js
+++ b/scripts/hijri-calendar/index.js
@@ -9,43 +9,45 @@
  * { year: {number}, <year>: [[M,D,iY], ... [M,D,iY,M,D,iY]], <year + 1>: {} ... }
  * ```
  * > Note: The library moment-hijri currently only provides dates between
- * > 1936 and 2080 which should be sufficient for our needs
+ * > 1356/1/1 (1937-03-14) and 1500/12/30 (2077-11-16) which should be
+ * > sufficient for our needs
  */
 
 const fs = require('fs')
 const path = require('path')
 const moment = require('moment-hijri')
 
+// 1 Muharram 1389 is at 1969-03-19 in gregorian year
+const START_YEAR = 1389
+
 const filename = path.resolve(__dirname, '../../src/internal/hijri-calendar.js')
-const out = {}
+const newYear = year => moment(`${year}-01-01 00:00:00`)
 
-const YEAR0 = 580
+const out = {
+  year: START_YEAR
+}
 
-// only years 1936 ... 2080 are supported by moment-hijri
-for (let y = 1969; y <= 2080; y++) {
-  const iy = y - YEAR0
+const endYear = newYear(2077).iYear()
 
-  if (!out.year) {
-    out.year = iy
-  }
-  const iyy = iy - out.year
-
+for (let iy = START_YEAR; iy <= endYear; iy++) {
   for (let im = 1; im <= 12; im++) {
-    const g = moment(iy + '/' + im + '/1', 'iYYYY/iM/iD')
+    const m = moment(iy + '/' + im + '/1', 'iYYYY/iM/iD')
 
-    const gy = g.year()
-    const gm = g.iMonth()
+    const iyy = iy - out.year
+
+    const gy = m.year()
+    const iim = m.iMonth()
 
     if (!out[gy]) {
       out[gy] = []
     }
 
-    const monthDateDiffYear = [g.month(), g.date(), iyy]
+    const monthDateDiffYear = [m.month(), m.date(), iyy]
 
-    if (out[gy][gm]) {
-      out[gy][gm] = out[gy][gm].concat(monthDateDiffYear)
+    if (out[gy][iim]) {
+      out[gy][iim] = out[gy][iim].concat(monthDateDiffYear)
     } else {
-      out[gy][gm] = monthDateDiffYear
+      out[gy][iim] = monthDateDiffYear
     }
   }
 }

--- a/src/CalEventMap.js
+++ b/src/CalEventMap.js
@@ -27,7 +27,7 @@ export default class CalEventMap extends CalEvent {
         if (this.opts.year) {
           const calYear = this.calendar.year + firstDays[i + 2]
           if (this.opts.year !== calYear) {
-            break
+            continue
           }
         }
         const d = (new CalDate({

--- a/test/CalEvent.mocha.js
+++ b/test/CalEvent.mocha.js
@@ -87,6 +87,55 @@ describe('#CalEventFactory', function () {
     // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
+
+  it('5 Jumada al-awwal 1440', function () {
+    const date = new CalEventFactory({
+      fn: 'islamic',
+      day: 5,
+      month: 5,
+      year: 1440
+    })
+    const res = date.inYear(2019).get()
+    const exp = [{
+      date: '2019-01-11 00:00:00 -0600',
+      end: 'fri 2019-01-11 18:00',
+      start: 'thu 2019-01-10 18:00'
+    }]
+    assert.deepStrictEqual(fixResult(res), exp)
+  })
+
+  it('5 Jumada al-awwal 1441', function () {
+    const date = new CalEventFactory({
+      fn: 'islamic',
+      day: 5,
+      month: 5,
+      year: 1441
+    })
+    const res = date.inYear(2019).get()
+    const exp = [{
+      date: '2019-12-31 00:00:00 -0600',
+      end: 'tue 2019-12-31 18:00',
+      start: 'mon 2019-12-30 18:00'
+    }]
+    assert.deepStrictEqual(fixResult(res), exp)
+  })
+
+  it('1 Muharram 1443', function () {
+    const date = new CalEventFactory({
+      fn: 'islamic',
+      day: 1,
+      month: 1,
+      year: 1443
+    })
+    const res = date.inYear(2021).get()
+    const exp = [{
+      date: '2021-08-09 00:00:00 -0600',
+      start: 'sun 2021-08-08 18:00',
+      end: 'mon 2021-08-09 18:00'
+    }]
+    // console.log(fixResult(res))
+    assert.deepStrictEqual(fixResult(res), exp)
+  })
 })
 
 describe('#CalEvent', function () {

--- a/test/CalEvent.mocha.js
+++ b/test/CalEvent.mocha.js
@@ -22,7 +22,6 @@ describe('#CalEventFactory', function () {
       start: 'thu 2015-12-03 00:00',
       end: 'fri 2015-12-04 00:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -37,7 +36,6 @@ describe('#CalEventFactory', function () {
       start: 'fri 2015-03-20 00:00',
       end: 'sat 2015-03-21 00:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -52,7 +50,6 @@ describe('#CalEventFactory', function () {
       start: 'thu 2015-04-02 00:00',
       end: 'fri 2015-04-03 00:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -68,7 +65,6 @@ describe('#CalEventFactory', function () {
       start: 'fri 2015-04-03 18:00',
       end: 'sat 2015-04-04 18:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -84,7 +80,6 @@ describe('#CalEventFactory', function () {
       start: 'sat 2015-07-18 18:00',
       end: 'sun 2015-07-19 18:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -133,7 +128,6 @@ describe('#CalEventFactory', function () {
       start: 'sun 2021-08-08 18:00',
       end: 'mon 2021-08-09 18:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 })
@@ -147,7 +141,6 @@ describe('#CalEvent', function () {
       start: 'thu 2015-12-03 00:00',
       end: 'fri 2015-12-04 00:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -159,7 +152,6 @@ describe('#CalEvent', function () {
       start: 'thu 2015-12-03 00:00',
       end: 'fri 2015-12-04 00:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -171,7 +163,6 @@ describe('#CalEvent', function () {
       start: 'thu 2015-12-03 00:00',
       end: 'fri 2015-12-04 00:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -179,7 +170,6 @@ describe('#CalEvent', function () {
     const date = new CalEvent({ year: 2015, month: 12, day: 3 })
     const res = date.inYear(2016).get()
     const exp = []
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -222,7 +212,6 @@ describe('#CalEvent', function () {
         end: 'fri 2015-12-04 00:00'
       }
     ]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -346,7 +335,6 @@ describe('#Easter', function () {
       start: 'thu 2015-04-02 00:00',
       end: 'fri 2015-04-03 00:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -358,7 +346,6 @@ describe('#Easter', function () {
       start: 'mon 2015-06-01 00:00',
       end: 'tue 2015-06-02 00:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 })
@@ -372,7 +359,6 @@ describe('#Equinox', function () {
       start: 'fri 2015-03-20 00:00',
       end: 'sat 2015-03-21 00:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -384,7 +370,6 @@ describe('#Equinox', function () {
       start: 'sat 2015-03-21 00:00',
       end: 'sun 2015-03-22 00:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -396,7 +381,6 @@ describe('#Equinox', function () {
       start: 'fri 2015-03-20 00:00',
       end: 'sat 2015-03-21 00:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -408,7 +392,6 @@ describe('#Equinox', function () {
       start: 'sat 2015-09-26 00:00',
       end: 'sun 2015-09-27 00:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 })
@@ -426,7 +409,6 @@ describe('#Hebrew', function () {
       start: 'fri 2015-04-03 18:00',
       end: 'sat 2015-04-04 18:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -441,7 +423,6 @@ describe('#Hebrew', function () {
       start: 'fri 2016-04-22 18:00',
       end: 'sat 2016-04-23 18:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -460,7 +441,6 @@ describe('#Hebrew', function () {
       start: 'tue 2015-12-29 18:00',
       end: 'wed 2015-12-30 18:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -471,7 +451,6 @@ describe('#Hebrew', function () {
     })
     const res = date.inYear(2016).get()
     const exp = []
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 })
@@ -489,7 +468,6 @@ describe('#Hijri', function () {
       start: 'sat 2015-07-18 18:00',
       end: 'sun 2015-07-19 18:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -509,7 +487,6 @@ describe('#Hijri', function () {
       start: 'sun 2016-12-25 18:00',
       end: 'mon 2016-12-26 18:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -525,7 +502,6 @@ describe('#Hijri', function () {
       start: 'sun 2016-12-25 18:00',
       end: 'mon 2016-12-26 18:00'
     }]
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 
@@ -536,7 +512,6 @@ describe('#Hijri', function () {
     })
     const res = date.inYear(1800).get()
     const exp = []
-    // console.log(fixResult(res))
     assert.deepStrictEqual(fixResult(res), exp)
   })
 })

--- a/test/DateFn.mocha.js
+++ b/test/DateFn.mocha.js
@@ -124,6 +124,28 @@ describe('#DateFn', function () {
         }]
         assert.deepStrictEqual(fixResult(res), exp)
       })
+
+      it('29 Dhu al-Hijjah 1442', function () {
+        const fn = new DateFn('29 Dhu al-Hijjah 1442')
+        const res = fn.inYear(2021).get()
+        const exp = [{
+          date: '2021-08-08 00:00:00 -0600',
+          start: 'sat 2021-08-07 18:00',
+          end: 'sun 2021-08-08 18:00'
+        }]
+        assert.deepStrictEqual(fixResult(res), exp)
+      })
+
+      it('1 Muharram 1443', function () {
+        const fn = new DateFn('1 Muharram 1443')
+        const res = fn.inYear(2021).get()
+        const exp = [{
+          date: '2021-08-09 00:00:00 -0600',
+          start: 'sun 2021-08-08 18:00',
+          end: 'mon 2021-08-09 18:00'
+        }]
+        assert.deepStrictEqual(fixResult(res), exp)
+      })
     })
 
     describe('hebrew calendar', function () {


### PR DESCRIPTION
CalEventMap loops over dates in the non-gregorian calendar but breaks
early. For some dates the exact given date can't be calculated.
Loop continuation fixes this issue.

refactor: hijri calendar map generation to improve readability
The resulting map is still the same.