### PR TITLE
Feat: if is holiday rule

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,6 +1,6 @@
 # Specification for `holidays.yaml`
 
-Version: 2.0.0
+Version: 2.1.0
 
 This document describes the data contained within the files `holidays.yaml` and
 `names.yaml`.
@@ -522,6 +522,20 @@ Where:
 
 - `09-22 if 09-21 is holiday` is September 22nd is public holiday only if September 21st is also a holiday
 - `09-22 if 09-21 and 09-23 is public holiday` is September 22nd is public holiday only if September 21st and September 23rd are public holidays
+
+### Change to different weekday if date already falls on a holiday 
+
+Rule: `<rule> if is holiday then (<count>)? (next|previous) <weekday>`
+
+Where:
+- `<rule>` any rule
+- `<count>` 1...31, 1st, 2nd, 3rd
+- `<weekday>` Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Day
+
+**Examples**:
+
+- `Thursday after 04-02 if is holiday then next Thursday`
+- `03-01 and if Saturday, Sunday then next Monday if is holiday then 2nd next Tuesday since 2022`
 
 ### Enabling a rule since or in certain years
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -525,17 +525,22 @@ Where:
 
 ### Change to different weekday if date already falls on a holiday 
 
-Rule: `<rule> if is holiday then (<count>)? (next|previous) <weekday>`
+Rule: `<rule> if is (<type>)? holiday then (<count>)? (next|previous) <weekday>`
+
+Rule: `<rule> if is (<type>)? holiday then (<count>)? (next|previous) day (omit <weekdays>)?`
 
 Where:
 - `<rule>` any rule
+- `<type>` public, bank, school, observance, optional (defaults to public if omitted)
 - `<count>` 1...31, 1st, 2nd, 3rd
-- `<weekday>` Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Day
+- `<weekday>` Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday
+- `<weekdays>` Comma separated list of `<weekday>`
 
 **Examples**:
 
-- `Thursday after 04-02 if is holiday then next Thursday`
+- `Thursday after 04-02 if is observance holiday then next Thursday`
 - `03-01 and if Saturday, Sunday then next Monday if is holiday then 2nd next Tuesday since 2022`
+- `05-01 if is public holiday then 2nd next day omit Saturday, Sunday`
 
 ### Enabling a rule since or in certain years
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "clean:node_modules": "rimraf node_modules",
     "coverage": "c8 -r text -r html npm test",
     "doc": "jsdox -o docs src/Holidays.js",
-    "lint": "eslint \"**/*.js\" \"**/*.cjs\"",
+    "lint": "eslint --fix --ext .js,.cjs .",
     "prepublishOnly": "npm run all",
     "test": "npm-run-all test:*",
     "test:ci": "mocha",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-holidays-parser",
-  "version": "3.2.4",
+  "version": "3.3.0-0",
   "description": "parser for worldwide holidays",
   "keywords": [
     "holidays",

--- a/src/DateFn.js
+++ b/src/DateFn.js
@@ -22,6 +22,10 @@ export default class DateFn {
     this.cache = new Map()
   }
 
+  /**
+   * @param {number} year
+   * @returns {this}
+   */
   inYear (year) {
     if (this.cache.has(year)) {
       this.event = this.cache.get(year)
@@ -32,9 +36,8 @@ export default class DateFn {
     const postProc = new PostRule(this.ruleStr, this.opts, this.holidays)
 
     this.rules.forEach((rule) => {
-      let calEvent
       if (rule.fn) {
-        calEvent = new CalEventFactory(rule)
+        const calEvent = new CalEventFactory(rule)
           .inYear(year - 1) // run over neighboring dates to catch overlaps
           .inYear(year)
           .inYear(year + 1)

--- a/src/Holidays.js
+++ b/src/Holidays.js
@@ -131,7 +131,7 @@ export class Holidays {
       return true
     } else {
       // throw Error('could not parse rule: ' + rule) // NEXT
-      console.log('could not parse rule: ' + rule) // eslint-disable-line
+      console.error('could not parse rule: ' + rule) // eslint-disable-line
     }
     return false
   }

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -9,6 +9,10 @@ const WEEKDAYS = 'Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday'.spli
 
 const lowerCaseWeekday = (weekday) => WEEKDAYS.includes(weekday) ? weekday.toLowerCase() : weekday
 
+const lowerCaseWeekdayWithoutDay = weekday => (weekday === 'day')
+  ? undefined
+  : lowerCaseWeekday(weekday)
+
 /**
  * regular expressions to parse holiday statements
  */
@@ -63,7 +67,7 @@ const grammar = (function () {
     rule_date_if_then: /^if ((?:(?:_weekdays)(?:,\s?)?)*) then (?:_direction _days)?/,
     rule_day_dir_date: /^(?:_counts )?_days _direction/,
     rule_bridge: /^is (?:_type )?holiday/,
-    rule_if_holiday: /^if is (?:_type )?holiday then (?:_counts )?(?:_direction _days)?/,
+    rule_if_holiday: /^if is (?:_type )?holiday then (?:_counts )?(?:_direction _days)?(?: omit ((?:(?:_weekdays)(?:,\s?)?)*))?/,
     rule_same_day: /^#\d+/,
     rule_active_from: /^since (0*\d{1,4})(?:-0*(\d{1,2})(?:-0*(\d{1,2})|)|)(?: and|)/,
     rule_active_to: /^prior to (0*\d{1,4})(?:-0*(\d{1,2})(?:-0*(\d{1,2})|)|)/,
@@ -115,6 +119,7 @@ const grammar = (function () {
   (/_counts/g, raw._counts)
   (/_direction/g, raw._direction)
   (/_days/g, raw._days)
+  (/_weekdays/g, raw._weekdays)
   ()
   raw.rule_day_dir_date = replace(raw.rule_day_dir_date, '')
   (/_counts/, raw._counts)
@@ -553,7 +558,8 @@ export default class Parser {
         type: cap.shift(),
         count: toNumber(cap.shift()) || 1,
         direction: cap.shift(),
-        weekday: lowerCaseWeekday(cap.shift())
+        weekday: lowerCaseWeekday(cap.shift()),
+        omit: (cap.shift() || '').split(/(?:,\s?)/).map(lowerCaseWeekdayWithoutDay).filter(Boolean)
       }
       this.tokens.push(res)
       return true

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -68,14 +68,20 @@ export default class Rule {
       const weekday = date.getDay()
       const ruleWeekday = DAYS[rule.weekday]
 
+      const isDirBefore = ['before', 'previous'].includes(rule.direction)
+      // correct count if weekday is same for next direction
+      if (rule.direction === 'next' && weekday === ruleWeekday) {
+        count += 1
+      }
+
       if (rule.weekday === 'day') {
-        if (rule.direction === 'before') {
+        if (isDirBefore) {
           offset = (count + 1) * -1
         } else {
           offset = count + 1
         }
       } else {
-        if (rule.direction === 'before') {
+        if (isDirBefore) {
           if (weekday === ruleWeekday) {
             count++
           }
@@ -179,6 +185,10 @@ export default class Rule {
   }
 
   bridge () {
+    return true // needs postprocessing
+  }
+
+  ruleIfHoliday () {
     return true // needs postprocessing
   }
 

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -3,7 +3,7 @@
  */
 
 import CalDate from 'caldate'
-import { DAYS } from './internal/utils.js'
+import { DAYS, isNil } from './internal/utils.js'
 
 export default class Rule {
   /**
@@ -58,10 +58,19 @@ export default class Rule {
    *   rule: "dateDir",
    *   count: 1,
    *   weekday: "tuesday",
-   *   direction: "after"
+   *   direction: "after",
+   *   omit: ['sunday']
    * }
    */
   dateDir (rule) {
+    const omitWeekdays = ([].concat(rule.omit)).map(weekday => DAYS[weekday]).filter(v => !isNil(v))
+
+    const isOmitDay = (offset, weekday) => {
+      let wd = offset + weekday
+      while (wd < 0) { wd += 70 }
+      return omitWeekdays.includes(wd % 7)
+    }
+
     this.calEvent.dates.forEach((date) => {
       let offset
       let count = rule.count - 1
@@ -75,10 +84,17 @@ export default class Rule {
       }
 
       if (rule.weekday === 'day') {
+        let i = 0
         if (isDirBefore) {
           offset = (count + 1) * -1
+          while (i++ < 7 && isOmitDay(offset, weekday)) {
+            offset -= 1
+          }
         } else {
           offset = count + 1
+          while (i++ < 7 && isOmitDay(offset, weekday)) {
+            offset += 1
+          }
         }
       } else {
         if (isDirBefore) {

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -27,6 +27,8 @@ export function isDate (d) {
   return isObject(d) && objectToString(d) === '[object Date]'
 }
 
+export const isNil = (v) => v === null || v === undefined
+
 /**
  * pad number with `0`
  * @param {number} number

--- a/test/DateFn.mocha.js
+++ b/test/DateFn.mocha.js
@@ -605,6 +605,17 @@ describe('#DateFn', function () {
       }]
       assert.deepStrictEqual(fixResult(res), exp)
     })
+
+    it('1 day before 11-23', function () {
+      const fn = new DateFn('1 day before 11-23')
+      const res = fn.inYear(2015).get()
+      const exp = [{
+        date: '2015-11-22 00:00:00',
+        start: 'sun 2015-11-22 00:00',
+        end: 'mon 2015-11-23 00:00'
+      }]
+      assert.deepStrictEqual(fixResult(res), exp)
+    })
   })
 
   describe('Change to different weekday if date falls on a certain weekday', function () {
@@ -1258,6 +1269,68 @@ describe('#DateFn', function () {
         end: 'fri 2019-03-15 00:00'
       }]
       assert.deepStrictEqual(fixResult(res), exp)
+    })
+
+    it('04-03 if is holiday then 3rd next day omit Saturday, Sunday', function () {
+      const ruleStr = '04-03 if is holiday then 3rd next day omit Saturday, Sunday'
+      const holidays = {
+        [ruleStr]: {
+          type: 'public'
+        },
+        '04-03': {
+          type: 'public'
+        }
+      }
+      Object.keys(holidays).forEach((rule) => {
+        holidays[rule].fn = new DateFn(rule, holidays)
+      })
+      const fn = new DateFn(ruleStr, holidays)
+      const res = fn.inYear(2019).get()
+      const exp = [{
+        date: '2019-04-08 00:00:00',
+        start: 'mon 2019-04-08 00:00',
+        end: 'tue 2019-04-09 00:00'
+      }]
+      assert.deepStrictEqual(fixResult(res), exp)
+
+      const res2020 = fn.inYear(2020).get()
+      const exp2020 = [{
+        date: '2020-04-06 00:00:00',
+        start: 'mon 2020-04-06 00:00',
+        end: 'tue 2020-04-07 00:00'
+      }]
+      assert.deepStrictEqual(fixResult(res2020), exp2020)
+    })
+
+    it('04-03 if is holiday then 3rd previous day omit Saturday, Sunday', function () {
+      const ruleStr = '04-03 if is holiday then 3rd previous day omit Saturday, Sunday'
+      const holidays = {
+        [ruleStr]: {
+          type: 'public'
+        },
+        '04-03': {
+          type: 'public'
+        }
+      }
+      Object.keys(holidays).forEach((rule) => {
+        holidays[rule].fn = new DateFn(rule, holidays)
+      })
+      const fn = new DateFn(ruleStr, holidays)
+      const res = fn.inYear(2019).get()
+      const exp = [{
+        date: '2019-03-29 00:00:00',
+        start: 'fri 2019-03-29 00:00',
+        end: 'sat 2019-03-30 00:00'
+      }]
+      assert.deepStrictEqual(fixResult(res), exp)
+
+      const res2020 = fn.inYear(2020).get()
+      const exp2020 = [{
+        date: '2020-03-31 00:00:00',
+        start: 'tue 2020-03-31 00:00',
+        end: 'wed 2020-04-01 00:00'
+      }]
+      assert.deepStrictEqual(fixResult(res2020), exp2020)
     })
 
     it('03-07 and if Saturday, Sunday then next Monday if is holiday then 2nd next Tuesday since 2022', function () {

--- a/test/DateFn.mocha.js
+++ b/test/DateFn.mocha.js
@@ -1159,6 +1159,131 @@ describe('#DateFn', function () {
     })
   })
 
+  describe('Already a Holiday', function () {
+    it('Thursday after 04-02 if is holiday then next Thursday', function () {
+      const ruleStr = 'Thursday after 04-02 if is holiday then next Thursday'
+      const holidays = {
+        [ruleStr]: {
+          type: 'public'
+        },
+        '04-04': {
+          type: 'public'
+        }
+      }
+      Object.keys(holidays).forEach((rule) => {
+        holidays[rule].fn = new DateFn(rule, holidays)
+      })
+      const fn = new DateFn(ruleStr, holidays)
+      const res = fn.inYear(2019).get()
+      const exp = [{
+        date: '2019-04-11 00:00:00',
+        start: 'thu 2019-04-11 00:00',
+        end: 'fri 2019-04-12 00:00'
+      }]
+      assert.deepStrictEqual(fixResult(res), exp)
+
+      const res2018 = fn.inYear(2018).get()
+      const exp2018 = [{
+        date: '2018-04-05 00:00:00',
+        start: 'thu 2018-04-05 00:00',
+        end: 'fri 2018-04-06 00:00'
+      }]
+      assert.deepStrictEqual(fixResult(res2018), exp2018)
+    })
+
+    it('Thursday after 04-02 if is holiday then 3rd next Thursday', function () {
+      const ruleStr = 'Thursday after 04-02 if is holiday then 3rd next Thursday'
+      const holidays = {
+        [ruleStr]: {
+          type: 'public'
+        },
+        '04-04': {
+          type: 'public'
+        }
+      }
+      Object.keys(holidays).forEach((rule) => {
+        holidays[rule].fn = new DateFn(rule, holidays)
+      })
+      const fn = new DateFn(ruleStr, holidays)
+      const res = fn.inYear(2019).get()
+      const exp = [{
+        date: '2019-04-25 00:00:00',
+        start: 'thu 2019-04-25 00:00',
+        end: 'fri 2019-04-26 00:00'
+      }]
+      assert.deepStrictEqual(fixResult(res), exp)
+    })
+
+    it('Thursday after 04-02 if is holiday then previous Thursday', function () {
+      const ruleStr = 'Thursday after 04-02 if is holiday then previous Thursday'
+      const holidays = {
+        [ruleStr]: {
+          type: 'public'
+        },
+        '04-04': {
+          type: 'public'
+        }
+      }
+      Object.keys(holidays).forEach((rule) => {
+        holidays[rule].fn = new DateFn(rule, holidays)
+      })
+      const fn = new DateFn(ruleStr, holidays)
+      const res = fn.inYear(2019).get()
+      const exp = [{
+        date: '2019-03-28 00:00:00',
+        start: 'thu 2019-03-28 00:00',
+        end: 'fri 2019-03-29 00:00'
+      }]
+      assert.deepStrictEqual(fixResult(res), exp)
+    })
+
+    it('Thursday after 04-02 if is holiday then 3rd previous Thursday', function () {
+      const ruleStr = 'Thursday after 04-02 if is holiday then 3rd previous Thursday'
+      const holidays = {
+        [ruleStr]: {
+          type: 'public'
+        },
+        '04-04': {
+          type: 'public'
+        }
+      }
+      Object.keys(holidays).forEach((rule) => {
+        holidays[rule].fn = new DateFn(rule, holidays)
+      })
+      const fn = new DateFn(ruleStr, holidays)
+      const res = fn.inYear(2019).get()
+      const exp = [{
+        date: '2019-03-14 00:00:00',
+        start: 'thu 2019-03-14 00:00',
+        end: 'fri 2019-03-15 00:00'
+      }]
+      assert.deepStrictEqual(fixResult(res), exp)
+    })
+
+    it('03-07 and if Saturday, Sunday then next Monday if is holiday then 2nd next Tuesday since 2022', function () {
+      const ruleStr = '03-07 and if Saturday, Sunday then next Monday if is holiday then 2nd next Tuesday since 2022'
+      const holidays = {
+        [ruleStr]: {
+          type: 'public'
+        },
+        '03-07': {
+          type: 'public'
+        }
+      }
+      Object.keys(holidays).forEach((rule) => {
+        holidays[rule].fn = new DateFn(rule, holidays)
+      })
+      const fn = new DateFn(ruleStr, holidays)
+      const res = fn.inYear(2022).get()
+      const exp = [{
+        date: '2022-03-15 00:00:00',
+        start: 'tue 2022-03-15 00:00',
+        end: 'wed 2022-03-16 00:00'
+      }]
+      assert.deepStrictEqual(fixResult(res), exp)
+    })
+  })
+
   describe('disable-enable rules', function () {
     it('11-01 disabled in 2015', function () {
       const holidays = {

--- a/test/Rule.mocha.js
+++ b/test/Rule.mocha.js
@@ -73,6 +73,38 @@ describe('#Rule', function () {
     assert.deepStrictEqual(fixResult(calEvent.get()), exp)
   })
 
+  it('can resolve rule dateDir using day count before omitting saturday', function () {
+    const tc = [
+      { fn: 'gregorian', year: undefined, month: 11, day: 23 },
+      { rule: 'dateDir', count: 4, weekday: 'day', direction: 'before', omit: ['saturday'] }
+    ]
+    const calEvent = new CalEventFactory(tc[0]).inYear(2016)
+    const ruleFn = new Rule()
+    ruleFn.setEvent(calEvent).resolve(tc[1])
+    const exp = [{
+      date: '2016-11-18 00:00:00',
+      start: 'fri 2016-11-18 00:00',
+      end: 'sat 2016-11-19 00:00'
+    }]
+    assert.deepStrictEqual(fixResult(calEvent.get()), exp)
+  })
+
+  it('can resolve rule dateDir using day count after omitting saturday, sunday', function () {
+    const tc = [
+      { fn: 'gregorian', year: undefined, month: 11, day: 23 },
+      { rule: 'dateDir', count: 4, weekday: 'day', direction: 'after', omit: ['saturday', 'sunday'] }
+    ]
+    const calEvent = new CalEventFactory(tc[0]).inYear(2016)
+    const ruleFn = new Rule()
+    ruleFn.setEvent(calEvent).resolve(tc[1])
+    const exp = [{
+      date: '2016-11-28 00:00:00',
+      start: 'mon 2016-11-28 00:00',
+      end: 'tue 2016-11-29 00:00'
+    }]
+    assert.deepStrictEqual(fixResult(calEvent.get()), exp)
+  })
+
   it('can resolve rule dateDir using day count after', function () {
     const tc = testcases['4 days after 11-27']
     const calEvent = new CalEventFactory(tc[0]).inYear(2016)

--- a/test/Rule.mocha.js
+++ b/test/Rule.mocha.js
@@ -99,7 +99,7 @@ describe('#Rule', function () {
     assert.deepStrictEqual(fixResult(calEvent.get()), exp)
   })
 
-  it('can resolve rule dateBridge', function () {
+  it('can resolve rule bridge', function () {
     const tc = testcases['09-22 if 09-21 is holiday']
     const calEvent = new CalEventFactory(tc[0]).inYear(2015)
     const ruleFn = new Rule()
@@ -108,6 +108,23 @@ describe('#Rule', function () {
       date: '2015-09-22 00:00:00',
       start: 'tue 2015-09-22 00:00',
       end: 'wed 2015-09-23 00:00'
+    }]
+    assert.deepStrictEqual(fixResult(calEvent.get()), exp)
+  })
+
+  it('can resolve if Holiday rule', function () {
+    const ruleStr = 'Thursday after 04-02 if is holiday then next Thursday'
+    const tc = testcases[ruleStr]
+
+    const calEvent = new CalEventFactory(tc[0]).inYear(2019)
+    const ruleFn = new Rule(calEvent)
+    ruleFn.resolve(tc[1])
+    ruleFn.resolve(tc[2])
+
+    const exp = [{
+      date: '2019-04-04 00:00:00',
+      start: 'thu 2019-04-04 00:00',
+      end: 'fri 2019-04-05 00:00'
     }]
     assert.deepStrictEqual(fixResult(calEvent.get()), exp)
   })

--- a/test/fixtures/parser.cjs
+++ b/test/fixtures/parser.cjs
@@ -1264,6 +1264,60 @@ module.exports = {
       type: undefined
     }
   ],
+  'Thursday after 04-02 if is holiday then next Thursday': [
+    {
+      day: 2,
+      fn: 'gregorian',
+      month: 4,
+      year: undefined
+    },
+    {
+      rule: 'dateDir',
+      count: 1,
+      direction: 'after',
+      weekday: 'thursday'
+    },
+    {
+      rule: 'ruleIfHoliday',
+      type: undefined,
+      count: 1,
+      direction: 'next',
+      weekday: 'thursday'
+    }
+  ],
+  '03-01 and if Saturday, Sunday then next Monday if is holiday then 2nd next Tuesday since 2022': [
+    {
+      day: 1,
+      fn: 'gregorian',
+      month: 3,
+      year: undefined
+    },
+    {
+      modifier: 'and'
+    },
+    {
+      direction: 'next',
+      if: [
+        'saturday',
+        'sunday'
+      ],
+      rule: 'dateIfThen',
+      then: 'monday'
+    },
+    {
+      rule: 'ruleIfHoliday',
+      type: undefined,
+      count: 2,
+      direction: 'next',
+      weekday: 'tuesday'
+    },
+    {
+      day: 1,
+      month: 1,
+      rule: 'activeFrom',
+      year: 2022
+    }
+  ],
   '09-22 on sunday, saturday': [
     {
       day: 22,

--- a/test/fixtures/parser.cjs
+++ b/test/fixtures/parser.cjs
@@ -1282,7 +1282,8 @@ module.exports = {
       type: undefined,
       count: 1,
       direction: 'next',
-      weekday: 'thursday'
+      weekday: 'thursday',
+      omit: []
     }
   ],
   '03-01 and if Saturday, Sunday then next Monday if is holiday then 2nd next Tuesday since 2022': [
@@ -1309,13 +1310,51 @@ module.exports = {
       type: undefined,
       count: 2,
       direction: 'next',
-      weekday: 'tuesday'
+      weekday: 'tuesday',
+      omit: []
     },
     {
       day: 1,
       month: 1,
       rule: 'activeFrom',
       year: 2022
+    }
+  ],
+  '05-01 if is holiday then next day omit Sunday': [
+    {
+      day: 1,
+      fn: 'gregorian',
+      month: 5,
+      year: undefined
+    },
+    {
+      rule: 'ruleIfHoliday',
+      type: undefined,
+      count: 1,
+      direction: 'next',
+      weekday: 'day',
+      omit: [
+        'sunday'
+      ]
+    }
+  ],
+  '05-01 if is holiday then next day omit Sunday, Saturday': [
+    {
+      day: 1,
+      fn: 'gregorian',
+      month: 5,
+      year: undefined
+    },
+    {
+      rule: 'ruleIfHoliday',
+      type: undefined,
+      weekday: 'day',
+      count: 1,
+      direction: 'next',
+      omit: [
+        'sunday',
+        'saturday'
+      ]
     }
   ],
   '09-22 on sunday, saturday': [


### PR DESCRIPTION
This PR adds a new rule which moves a holiday in case that day already observes a different holiday. 

### Change to different weekday if date already falls on a holiday 

Rule: `<rule> if is (<type>)? holiday then (<count>)? (next|previous) <weekday>`

Rule: `<rule> if is (<type>)? holiday then (<count>)? (next|previous) day (omit <weekdays>)?`

Where:
- `<rule>` any rule
- `<type>` public, bank, school, observance, optional (defaults to public if omitted)
- `<count>` 1...31, 1st, 2nd, 3rd
- `<weekday>` Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday
- `<weekdays>` Comma separated list of `<weekday>`

**Examples**:

- `Thursday after 04-02 if is observance holiday then next Thursday`
- `03-01 and if Saturday, Sunday then next Monday if is holiday then 2nd next Tuesday since 2022`
- `05-01 if is public holiday then 2nd next day omit Saturday, Sunday`
