### PR TITLE
feat: support for jalaali calendar

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,6 +1,6 @@
 # Specification for `holidays.yaml`
 
-Version: 2.1.0
+Version: 2.2.0
 
 This document describes the data contained within the files `holidays.yaml` and
 `names.yaml`.
@@ -11,9 +11,9 @@ This document describes the data contained within the files `holidays.yaml` and
 
 * [structure of `names.yaml`](#structure-of-namesyaml)
 * [structure of `holidays.yaml`](#structure-of-holidaysyaml)
-* [Types of holidays](#types-of-holidays)
 * [Citations, Sources, and Attribution](#citations-sources-and-attribution)
   * [Source Guidelines](#source-guidelines)
+* [Types of holidays](#types-of-holidays)
 * [Grammar for day rules](#grammar-for-day-rules)
   * [Fixed Date](#fixed-date)
   * [Fixed Date at beginning of a Month](#fixed-date-at-beginning-of-a-month)
@@ -24,6 +24,7 @@ This document describes the data contained within the files `holidays.yaml` and
     * [Dates in Chinese calendar (lunar)](#dates-in-chinese-calendar-lunar)
     * [Dates in Chinese calendar (solar)](#dates-in-chinese-calendar-solar)
     * [Dates in Bengali Revised calendar](#dates-in-bengali-revised-calendar)
+    * [Dates in Persian calendar](#dates-in-persian-calendar)
     * [Equinox, Solstice](#equinox-solstice)
   * [Different start-time for Fixed Date other than midnight](#different-start-time-for-fixed-date-other-than-midnight)
   * [Different duration other than 24 hours](#different-duration-other-than-24-hours)
@@ -38,6 +39,7 @@ This document describes the data contained within the files `holidays.yaml` and
   * [Enable Date only for certain periods of years](#enable-date-only-for-certain-periods-of-years)
   * [Enable Date only for certain weekdays](#enable-date-only-for-certain-weekdays)
   * [Holiday based on other holidays (bridge days)](#holiday-based-on-other-holidays-bridge-days)
+  * [Change to different weekday if date already falls on a holiday](#change-to-different-weekday-if-date-already-falls-on-a-holiday)
   * [Enabling a rule since or in certain years](#enabling-a-rule-since-or-in-certain-years)
   * [Disabling a rule](#disabling-a-rule)
   * [Moving a date](#moving-a-date)
@@ -314,6 +316,20 @@ Where:
 - `bengali-revised 12-1` is the 1st day in the 12th month
 - `bengali-revised 1425-1-1` is the 1st day in the first month of 1425 - equals 2018-04-14 in Gregorian date
 
+#### Dates in Persian calendar
+
+Dates in the persian calendar can be attributed using the following rule:
+
+Rule: `<day-of-month> (Farvardin|Ordibehesht|Khordad|Tir|Mordad|Shahrivar|Mehr|Aban|Azar|Dey|Bahman|Esfand) [<year>]`
+
+Where:
+- `<day-of-month>` [1..30]
+- `<year>` optional year
+
+**Examples**:
+
+- `1 Farvardin` is 1st day in month Farvardin
+
 #### Equinox, Solstice
 
 To calculate a date from Spring, Autumn Equinox or Summer, Winter Solstice the following rule can be used:
@@ -523,7 +539,7 @@ Where:
 - `09-22 if 09-21 is holiday` is September 22nd is public holiday only if September 21st is also a holiday
 - `09-22 if 09-21 and 09-23 is public holiday` is September 22nd is public holiday only if September 21st and September 23rd are public holidays
 
-### Change to different weekday if date already falls on a holiday 
+### Change to different weekday if date already falls on a holiday
 
 Rule: `<rule> if is (<type>)? holiday then (<count>)? (next|previous) <weekday>`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-holidays-parser",
-  "version": "3.3.0",
+  "version": "3.4.0-0",
   "description": "parser for worldwide holidays",
   "keywords": [
     "holidays",
@@ -66,6 +66,7 @@
     "date-chinese": "^2.1.3",
     "date-easter": "^1.0.1",
     "deepmerge": "^4.2.2",
+    "jalaali-js": "^1.2.4",
     "moment-timezone": "^0.5.34"
   },
   "devDependencies": {

--- a/scripts/rollup-fix/CalEventFactory.cjs
+++ b/scripts/rollup-fix/CalEventFactory.cjs
@@ -7,6 +7,9 @@ const Easter = require('./Easter.cjs')
 // #ifndef nojulian
 const Julian = require('./Julian.cjs')
 // #endif
+// #ifndef nojalaali
+const Jalaali = require('./Jalaali.cjs')
+// #endif
 // #ifndef nohebrew
 const Hebrew = require('./Hebrew.cjs')
 // #endif
@@ -41,6 +44,10 @@ class CalEventFactory {
       // #ifndef noislamic
       case 'islamic':
         return new Hijri(opts)
+      // #endif
+      // #ifndef nojalaali
+      case 'jalaali':
+        return new Jalaali(opts)
       // #endif
       // #ifndef noequinox
       case 'equinox':

--- a/src/CalEvent.js
+++ b/src/CalEvent.js
@@ -2,6 +2,15 @@ import { isDate } from './internal/utils.js'
 import CalDate from 'caldate'
 
 export default class CalEvent {
+  /**
+   * @param {object|Date} opts
+   * @param {string} opts.fn function type
+   * @param {number} [opts.day]
+   * @param {number} [opts.month]
+   * @param {number} [opts.year]
+   * @param {number} [opts.offset]
+   * @param {boolean} [opts.substitute]
+   */
   constructor (opts) {
     opts = opts || {}
     this.substitute = opts.substitute
@@ -14,6 +23,10 @@ export default class CalEvent {
     }
   }
 
+  /**
+   * @param {number} year
+   * @returns {this}
+   */
   inYear (year) {
     const d = (new CalDate(this.opts)).setOffset(this.offset)
     if (!(d.year && d.year !== year)) {
@@ -27,6 +40,10 @@ export default class CalEvent {
     this.dates = []
   }
 
+  /**
+   * @param {CalEvent} calEvent
+   * @returns {boolean}
+   */
   isEqualDate (calEvent) {
     let res = false
     for (const thisDate of this.dates) {
@@ -59,8 +76,8 @@ export default class CalEvent {
   }
 
   /**
-   * @param {Number} year - year to filter
-   * @param {Object[]} active - definition of active ranges `{from: {Date}, [to]: {Date}}`
+   * @param {number} year - year to filter
+   * @param {object[]} active - definition of active ranges `{from: {Date}, [to]: {Date}}`
    * @return {this} for chaining
    */
   filterActive (year, active = this.active) {
@@ -73,6 +90,12 @@ export default class CalEvent {
     return this
   }
 
+  /**
+   * @param {object} active
+   * @param {Date} [active.from ]
+   * @param {Date} [active.to]
+   * @returns
+   */
   setActive (active) {
     const { from, to } = active
     let pushIt = true
@@ -91,12 +114,19 @@ export default class CalEvent {
     return this
   }
 
+  /**
+   * @param {CalEvent} calEvent
+   */
   push (calEvent) {
     if (calEvent && Array.isArray(calEvent.dates)) {
       this.dates = this.dates.concat(calEvent.dates)
     }
   }
 
+  /**
+   * @param {string} timezone
+   * @returns
+   */
   get (timezone) {
     const arr = this.dates.map((date) => {
       const cdate = new CalDate(date)

--- a/src/CalEventFactory.js
+++ b/src/CalEventFactory.js
@@ -13,6 +13,9 @@ import Hebrew from './Hebrew.js'
 // #ifndef noislamic
 import Hijri from './Hijri.js'
 // #endif
+// #ifndef nojalaali
+import Jalaali from './Jalaali.js'
+// #endif
 // #ifndef noequinox
 import Equinox from './Equinox.js'
 // #endif
@@ -39,6 +42,10 @@ export default class CalEventFactory {
       // #ifndef noislamic
       case 'islamic':
         return new Hijri(opts)
+      // #endif
+      // #ifndef nojalaali
+      case 'jalaali':
+        return new Jalaali(opts)
       // #endif
       // #ifndef noequinox
       case 'equinox':

--- a/src/Jalaali.js
+++ b/src/Jalaali.js
@@ -1,0 +1,24 @@
+import CalDate from 'caldate'
+import CalEvent from './CalEvent.js'
+import jalaali from 'jalaali-js'
+
+const { toJalaali, toGregorian } = jalaali
+
+export default class Jalaali extends CalEvent {
+  /**
+   * @param {number} year gregorian year
+   * @returns
+   */
+  inYear (year) {
+    const nowruz = toJalaali(year, 1, 1)
+
+    if (this.opts.year && nowruz.jy !== this.opts.year) {
+      return this
+    }
+    const { gy, gm, gd } = toGregorian(this.opts.year || nowruz.jy, this.opts.month, this.opts.day)
+
+    const d = (new CalDate({ year: gy, month: gm, day: gd })).setOffset(this.offset)
+    this.dates.push(d)
+    return this
+  }
+}

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -40,6 +40,7 @@ const grammar = (function () {
     _months: 'January|February|March|April|May|June|July|August|September|October|November|December',
     _islamicMonths: 'Muharram|Safar|Rabi al-awwal|Rabi al-thani|Jumada al-awwal|Jumada al-thani|Rajab|Shaban|Ramadan|Shawwal|Dhu al-Qidah|Dhu al-Hijjah',
     _hebrewMonths: 'Nisan|Iyyar|Sivan|Tamuz|Av|Elul|Tishrei|Cheshvan|Kislev|Tevet|Shvat|AdarII|Adar',
+    _jalaaliMonths: 'Farvardin|Ordibehesht|Khordad|Tir|Mordad|Shahrivar|Mehr|Aban|Azar|Dey|Bahman|Esfand',
     _days: /(_weekdays)s?/,
     _direction: /(before|after|next|previous|in)/,
     _counts: /(\d+)(?:st|nd|rd|th)?/,
@@ -57,6 +58,7 @@ const grammar = (function () {
     equinox: /^([Mm]arch|[Jj]une|[Ss]eptember|[Dd]ecember) (?:equinox|solstice)(?:_timezone)?/,
     hebrew: /^0?(\d{1,2}) (_hebrewMonths)(?: 0*(\d{1,}))?/,
     islamic: /^0?(\d{1,2}) (_islamicMonths)(?: 0*(\d{1,}))?/,
+    jalaali: /^0?(\d{1,2}) (_jalaaliMonths)(?: 0*(\d{1,}))?/,
     chineseLunar: /^(chinese|korean|vietnamese) (?:(\d+)-(\d{1,2})-)?(\d{1,2})-([01])-(\d{1,2})/,
     chineseSolar: /^(chinese|korean|vietnamese) (?:(\d+)-(\d{1,2})-)?(\d{1,2})-(\d{1,2}) solarterm/,
     bengaliRevised: /^(bengali-revised) (?:-?0*(\d{1,4})-)?0?(\d{1,2})-0?(\d{1,2})/,
@@ -98,6 +100,9 @@ const grammar = (function () {
   ()
   raw.islamic = replace(raw.islamic, '')
   (/_islamicMonths/, raw._islamicMonths)
+  ()
+  raw.jalaali = replace(raw.jalaali, '')
+  (/_jalaaliMonths/, raw._jalaaliMonths)
   ()
   raw.dateMonth = replace(raw.dateMonth)
   (/_months/, raw._months)
@@ -152,6 +157,12 @@ const grammar = (function () {
   raw.hebrewMonths.Adar = 12
   raw.hebrewMonths.AdarII = 13
 
+  i = 1
+  raw.jalaaliMonths = {}
+  raw._jalaaliMonths.split('|').forEach(function (m) {
+    raw.jalaaliMonths[m] = i++
+  })
+
   return raw
   /* eslint-enable */
 })()
@@ -166,6 +177,7 @@ export default class Parser {
       '_easter',
       '_islamic',
       '_hebrew',
+      '_jalaali',
       '_equinox',
       '_chineseSolar',
       '_chineseLunar',
@@ -334,6 +346,22 @@ export default class Parser {
         fn: 'islamic',
         day: toNumber(cap.shift()),
         month: grammar.islamicMonths[cap.shift()],
+        year: toNumber(cap.shift())
+      }
+      this.tokens.push(res)
+      return true
+    }
+  }
+
+  _jalaali (o) {
+    let cap
+    if ((cap = grammar.jalaali.exec(o.str))) {
+      this._shorten(o, cap[0])
+      cap.shift()
+      const res = {
+        fn: 'jalaali',
+        day: toNumber(cap.shift()),
+        month: grammar.jalaaliMonths[cap.shift()],
         year: toNumber(cap.shift())
       }
       this.tokens.push(res)

--- a/test/DateFn.mocha.js
+++ b/test/DateFn.mocha.js
@@ -148,6 +148,31 @@ describe('#DateFn', function () {
       })
     })
 
+    describe('jalaali dates', function () {
+      // jalaali calendar
+      it('1 Farvardin', function () {
+        const fn = new DateFn('1 Farvardin')
+        const res = fn.inYear(2022).get()
+        const exp = [{
+          date: '2022-03-21 00:00:00',
+          end: 'tue 2022-03-22 00:00',
+          start: 'mon 2022-03-21 00:00'
+        }]
+        assert.deepStrictEqual(fixResult(res), exp)
+      })
+
+      it('29 Esfand 1400', function () {
+        const fn = new DateFn('29 Esfand 1400')
+        const res = fn.inYear(2022).get()
+        const exp = [{
+          date: '2022-03-20 00:00:00',
+          end: 'mon 2022-03-21 00:00',
+          start: 'sun 2022-03-20 00:00'
+        }]
+        assert.deepStrictEqual(fixResult(res), exp)
+      })
+    })
+
     describe('hebrew calendar', function () {
       // hebrew calendar
       it('15 Nisan 5775', function () {

--- a/test/fixtures/parser.cjs
+++ b/test/fixtures/parser.cjs
@@ -301,6 +301,30 @@ module.exports = {
       year: undefined
     }
   ],
+  '1 Farvardin': [
+    {
+      day: 1,
+      fn: 'jalaali',
+      month: 1,
+      year: undefined
+    }
+  ],
+  '31 Shahrivar 1401': [
+    {
+      day: 31,
+      fn: 'jalaali',
+      month: 6,
+      year: 1401
+    }
+  ],
+  '29 Esfand 1401': [
+    {
+      day: 29,
+      fn: 'jalaali',
+      month: 12,
+      year: 1401
+    }
+  ],
   'chinese 01-0-01': [
     {
       fn: 'chinese',


### PR DESCRIPTION
- adds support for Persian Jalaali Calendar based on [jalaali-js](https://www.npmjs.com/package/jalaali-js). 
- Required to support holidays in Iran 