### PR TITLE
removed 'Reformation Day' from BW, not a holiday there

### DIFF
--- a/test/fixtures/holidays.json
+++ b/test/fixtures/holidays.json
@@ -6849,10 +6849,6 @@
             "easter 60": {
               "_name": "easter 60"
             },
-            "10-31": {
-              "_name": "Reformation Day",
-              "type": "school"
-            },
             "11-01": {
               "_name": "11-01"
             }


### PR DESCRIPTION
Reformation Day was only a holiday in 2017 in Baden-Württemberg (BW) in Germany. It is no longer a public and official holiday.